### PR TITLE
Fix references to removed np.int and np.float

### DIFF
--- a/dfogn/dfogn_resampling.py
+++ b/dfogn/dfogn_resampling.py
@@ -125,7 +125,7 @@ class Model:
         self.EXACT_CONST_TERM = True  # use exact c=r(xopt) for interpolation (improve conditioning)
         # Affects mini-model interpolation / interpolation matrix, but also geometry updating
 
-        self.nsamples = np.zeros((npt,), dtype=np.int)  # how many samples we have averaged to get fval_v, where fval = sumsq(avg fval_v)
+        self.nsamples = np.zeros((npt,), dtype=int)  # how many samples we have averaged to get fval_v, where fval = sumsq(avg fval_v)
 
     def x_within_bounds(self, k=None, x=None):
         # Get x value for k-th point or x vector (in absolute terms, force within bounds)

--- a/dfogn/tests/test_util.py
+++ b/dfogn/tests/test_util.py
@@ -53,11 +53,11 @@ class TestEval(unittest.TestCase):
 class TestModelValue(unittest.TestCase):
     def runTest(self):
         n = 5
-        A = np.arange(n ** 2, dtype=np.float).reshape((n, n))
+        A = np.arange(n ** 2, dtype=float).reshape((n, n))
         H = np.sin(A + A.T)  # force symmetric
         hess = to_upper_triangular_vector(H)
-        vec = np.exp(np.arange(n, dtype=np.float))
-        g = np.cos(3*np.arange(n, dtype=np.float) - 2.0)
+        vec = np.exp(np.arange(n, dtype=float))
+        g = np.cos(3*np.arange(n, dtype=float) - 2.0)
         mval = np.dot(g, vec) + 0.5 * np.dot(vec, np.dot(H, vec))
         self.assertAlmostEqual(mval, calculate_model_value(g, hess, vec), 'Wrong value')
 
@@ -66,7 +66,7 @@ class TestInitFromMatrix(unittest.TestCase):
     def runTest(self):
         n = 3
         nvals = n*(n+1)//2
-        A = np.arange(n**2, dtype=np.float).reshape((n,n))
+        A = np.arange(n**2, dtype=float).reshape((n,n))
         hess = to_upper_triangular_vector(A+A.T)  # force symmetric
         self.assertEqual(len(hess), nvals, 'Wrong length')
         self.assertTrue(np.all(hess == np.array([0.0, 4.0, 8.0, 8.0, 12.0, 16.0])),
@@ -76,7 +76,7 @@ class TestInitFromMatrix(unittest.TestCase):
 class TestToFull(unittest.TestCase):
     def runTest(self):
         n = 7
-        A = np.arange(n ** 2, dtype=np.float).reshape((n, n))
+        A = np.arange(n ** 2, dtype=float).reshape((n, n))
         H = A + A.T  # force symmetric
         hess = to_upper_triangular_vector(H)
         self.assertTrue(np.all(to_full_matrix(n, hess) == H), 'Wrong values')
@@ -85,7 +85,7 @@ class TestToFull(unittest.TestCase):
 class TestGetElementGood(unittest.TestCase):
     def runTest(self):
         n = 3
-        A = np.arange(n ** 2, dtype=np.float).reshape((n, n))
+        A = np.arange(n ** 2, dtype=float).reshape((n, n))
         H = A + A.T  # force symmetric
         hess = to_upper_triangular_vector(H)
         for i in range(n):
@@ -98,9 +98,9 @@ class TestGetElementGood(unittest.TestCase):
 class TestMultGood(unittest.TestCase):
     def runTest(self):
         n = 5
-        A = np.arange(n ** 2, dtype=np.float).reshape((n, n))
+        A = np.arange(n ** 2, dtype=float).reshape((n, n))
         H = np.sin(A + A.T)  # force symmetric
         hess = to_upper_triangular_vector(H)
-        vec = np.exp(np.arange(n, dtype=np.float))
+        vec = np.exp(np.arange(n, dtype=float))
         hs = np.dot(H, vec)
         self.assertTrue(array_compare(right_multiply_hessian(hess, vec), hs, thresh=1e-12), 'Wrong values')

--- a/dfogn/trust_region.py
+++ b/dfogn/trust_region.py
@@ -59,7 +59,7 @@ def trsbox(xopt, gopt, hq, sl, su, delta):
     iterc = 0
     nact = 0  # number of fixed variables
 
-    xbdi = np.zeros((n,), dtype=np.int)  # fix x_i at bounds? [values -1, 0, 1
+    xbdi = np.zeros((n,), dtype=int)  # fix x_i at bounds? [values -1, 0, 1
     xbdi[(xopt <= sl) & (gopt >= 0.0)] = -1
     xbdi[(xopt >= su) & (gopt <= 0.0)] = 1
 


### PR DESCRIPTION
Numpy recently removed the deprecated `np.int` and `np.float` in [`numpy==1.24`](https://github.com/numpy/numpy/releases/tag/v1.24.0).

This means that DFOGN doesn't work with the latest version of numpy and gives an `AttributeError: module 'numpy' has no attribute 'int'`.

Looking at the original deprecation the python builtin can be used directly with no change to the code (usually). If you want to specify the precision, more guidance can be found in the deprecation message: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations


An alternative would be pinning the numpy version to be `<1.24.0`, although it looked like this would need a few docs changes.